### PR TITLE
Update README with additional dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ x11fs: $(BINDIR) $(OBJ)
 	$(LD) $(OBJ) $(LIBS) -o $(BINDIR)/$@
 
 install: x11fs
+	mkdir -p $(DESTDIR)$(PREFIX)/bin/
 	cp $(BINDIR)/x11fs $(DESTDIR)$(PREFIX)/bin/
 
 uninstall:

--- a/README
+++ b/README
@@ -7,7 +7,7 @@ This allows windows to be controlled using any language or tool with simple file
 
 Build:
 
-After installing the relevant developement packages for fuse and xcb for your distro (on Ubuntu these are libxcb1-dev and libfuse-dev), x11fs can be built using the make command.
+After installing the relevant developement packages for fuse and xcb for your distro (on Ubuntu these are libxcb1-dev, libxcb-icccm4-dev and libfuse-dev), x11fs can be built using the make command.
 Installation can be done by invoking make install.
 
 


### PR DESCRIPTION
At least in Ubuntu 15.10, libxcb-icccm4-dev isn't a dependency of libxcb1-dev.

Also attempt to create the target directory before installing.
