### PR TITLE
Add Gentoo packages list, rework on Build section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ This allows windows to be controlled using any language or tool with simple file
 Build
 -----
 
-After installing the relevant developement packages for fuse and xcb for your distro (on Ubuntu these are libxcb1-dev, libxcb-icccm4-dev and libfuse-dev), x11fs can be built using the make command.
-Installation can be done by invoking make install.
+After installing the FUSE and XCB developement packages, x11fs can be built using the `make` command. Installation can be done by invoking `make install`.
 
+On distros, the development packages are:
+
+* Gentoo: `x11-libs/libxcb x11-libs/xcb-util-wm sys-fs/fuse`
+* Ubuntu: `libxcb1-dev libxcb-icccm4-dev libfuse-dev`
 
 Usage
 -----


### PR DESCRIPTION
The list is in alphabetical order, even Ubuntu is way more popular, but considering the list might grow, the order could be a better choice.

The packages are in literal text (for better looking), as space-separated list, it's for user's convenience, they can just copy and paste the list to use with package managers.