### PR TITLE
docs: fix simple typo, vitual -> virtual

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ x11fs X window virtual filesystem
 *This is heavily based off wmutils. [Check them out](http://wmutils.io).*
 
 x11fs is a tool for manipulating X windows.
-It creates a vitual filesystem to represent open windows, similar to what /proc does for processes.
+It creates a virtual filesystem to represent open windows, similar to what /proc does for processes.
 This allows windows to be controlled using any language or tool with simple file IO, in a true unix fashion.
 
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `virtual` rather than `vitual`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md